### PR TITLE
feat(GST): GST provider larger support (#330)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ yarn-error.log
 # System Files
 .DS_Store
 Thumbs.db
+.history/

--- a/src/lib/core/angulartics2-config.ts
+++ b/src/lib/core/angulartics2-config.ts
@@ -17,6 +17,9 @@ export interface GoogleTagManagerSettings {
 
 export interface GoogleGlobalSiteTagSettings {
   trackingIds: any;
+  userId?: any;
+  anonymizeIp?: boolean;
+  customMap?: { [key: string]: string };
 }
 
 export interface PageTrackingSettings {

--- a/src/lib/providers/gst/README.md
+++ b/src/lib/providers/gst/README.md
@@ -49,6 +49,58 @@ export class AppComponent {
 }
 ```
 
+### Custom dimension
+
+`custom_map` you could set inside your HTML page will be overridden after each pagetrack. Therefore, you need to pass them to the GST configuration if you want to use them. At this point, you're probably better to remove completely the `gtag('config'` call from you HTML page and to add all required properties at module definition.
+
+```ts
+// bootstrap
+import { Angulartics2Module } from 'angulartics2';
+
+@NgModule({
+  imports: [
+    ...
+    // import Angulartics2GoogleGlobalSiteTag in root ngModule
+    Angulartics2Module.forRoot(
+      gst: {
+        trackingIds: ['UA-11111111-1'],
+        customMap: {
+          dimension1: 'version',
+          dimension2: 'page_language',
+          dimension3: 'custom_dimension_name'
+        },
+        anonymizeIp: true
+      },
+    )
+  ],
+})
+export class AppModule { }
+```
+
+Then, you can user the normal angulartic approach:
+
+```
+this.angulartics2.setUserProperties.next({
+  custom_dimension_name: 'example'
+});
+```
+
+You can also pass custom dimension with a specific event using the `gstCustom` property
+
+```
+constructor(private angulartics2: Angulartics2) {
+  this.angulartics2.eventTrack.next({ 
+    action: 'myAction', 
+    properties: {
+      category: 'myCategory'
+      gstCustom: {
+        custom_dimension_name: 'example'
+      }
+    },
+  });
+}
+```
+
 ### Send tracking events in a component or template
 
 _Check out the documentation for [Tracking Events](https://github.com/angulartics/angulartics2/wiki/Tracking-Events)._

--- a/src/lib/providers/gst/gst-interfaces.ts
+++ b/src/lib/providers/gst/gst-interfaces.ts
@@ -9,3 +9,11 @@ export interface UserTimingsGst {
   /** A string that can be used to add flexibility in visualizing user timings in the reports (e.g. 'Google CDN'). */
   label?: string;
 }
+
+export interface EventGst {
+  category: string;
+  label?: string;
+  value?: number | string;
+  noninteraction?: boolean;
+  gstCustom?: any;
+}


### PR DESCRIPTION
### What kind of change does this PR introduce?

This PR increase the GST provider support.

- Add support for setUsername and setUserProperties
- Add page_location on pageTrack because this seems logical
- Add interface for gst Event properties
- Add support for anonimyzeIp
- Add security check if tracking ID is duplicated in HTML and forRoot config
- Extends documentation accordingly
- Support for custom_map

### Link to open issue?
Mostly linked to #273 #155

### Notes

Multiple setUserProperties will be merge together, instead of using only the most recent one:
```
this.angulartics2.setUserProperties.next({ page_language: 'en_us' });
this.angulartics2.setUserProperties.next({ user_type: 'member' });
this.angulartics2.setUserProperties.next({ page_language: 'en_gb' });
```
will result in `{page_langue: 'en_gb', user_type: 'member'}` being sent with all later event/page track.

- **What kind of change does this PR introduce?**


- **What is the current behavior? Link to open issue?**


- **What is the new behavior?**
